### PR TITLE
simplify xyz to just use one struct read and do the scaling in a listcomp

### DIFF
--- a/adafruit_msa301.py
+++ b/adafruit_msa301.py
@@ -47,12 +47,10 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MSA301.git"
 
-import struct
-
 from micropython import const
 from adafruit_register.i2c_struct import Struct, ROUnaryStruct
 from adafruit_register.i2c_bit import RWBit
-from adafruit_register.i2c_bits import RWBits, ROBits
+from adafruit_register.i2c_bits import RWBits
 import adafruit_bus_device.i2c_device as i2cdevice
 
 _MSA301_I2CADDR_DEFAULT = const(0x26)

--- a/adafruit_msa301.py
+++ b/adafruit_msa301.py
@@ -207,7 +207,7 @@ class TapDuration:  # pylint: disable=too-few-public-methods,too-many-instance-a
 class MSA301:  # pylint: disable=too-many-instance-attributes
     """Driver for the MSA301 Accelerometer.
 
-        :param ~busio.I2C i2c_bus: The I2C bus the MSA is connected to.
+    :param ~busio.I2C i2c_bus: The I2C bus the MSA is connected to.
     """
 
     _part_id = ROUnaryStruct(_MSA301_REG_PARTID, "<B")
@@ -230,7 +230,7 @@ class MSA301:  # pylint: disable=too-many-instance-attributes
     _disable_y = RWBit(_MSA301_REG_ODR, 6)
     _disable_z = RWBit(_MSA301_REG_ODR, 5)
 
-    #_xyz_raw = ROBits(48, _MSA301_REG_OUT_X_L, 0, 6)
+    # _xyz_raw = ROBits(48, _MSA301_REG_OUT_X_L, 0, 6)
     _xyz_raw = Struct(_MSA301_REG_OUT_X_L, "<hhh")
 
     # tap INT enable and status


### PR DESCRIPTION
fix a complaint about `OverflowError: small int overflow`